### PR TITLE
add support for getting container ID and task ID for AWS ECS

### DIFF
--- a/test/fixtures/ecs-container-metadata.json
+++ b/test/fixtures/ecs-container-metadata.json
@@ -1,0 +1,3 @@
+{
+  "ContainerID": "34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,8 @@ const tap = require('tap')
 const data = fs.readFileSync(path.join(__dirname, 'fixtures', 'cgroup'))
 const expected = require('./fixtures/result')
 
+process.env.ECS_CONTAINER_METADATA_FILE = path.join(__dirname, 'fixtures', 'ecs-container-metadata.json')
+
 const containerInfo = require('../')
 const { parse, sync } = containerInfo
 
@@ -193,6 +195,22 @@ tap.test('basics', t => {
         controllers: ['name=systemd'],
         containerId: '2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63',
         podId: '90d81341_92de_11e7_8cf2_507b9d4141fa'
+      }
+    ]
+  })
+
+  t.deepEqual(parse(`
+    1:name=systemd:/ecs/46686c7c701cdfdf2549f88f7b9575e9/46686c7c701cdfdf2549f88f7b9575e9-2574839563
+  `), {
+    containerId: '34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+    taskId: '46686c7c701cdfdf2549f88f7b9575e9',
+    entries: [
+      {
+        id: '1',
+        groups: 'name=systemd',
+        path: '/ecs/46686c7c701cdfdf2549f88f7b9575e9/46686c7c701cdfdf2549f88f7b9575e9-2574839563',
+        controllers: ['name=systemd'],
+        taskId: '46686c7c701cdfdf2549f88f7b9575e9'
       }
     ]
   })


### PR DESCRIPTION
ECS recently changed their cgroup to allow grouping by task ID, and in the process they removed the container ID from it. They do provide however a metadata file that can be used to get the container ID as well as other information about the ECS task and container. While this unfortunately must be explicitly enabled on the ECS container agent, it is now the only way to get the container ID in that environment until Docker adds an official way to do this.

More information can be found in https://github.com/aws/amazon-ecs-agent/issues/1119 and in the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html).